### PR TITLE
minor naming updates for consistency and clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ export AWS_PROFILE=your-profile-name
 ```hcl
 vpc_id = ""  # Leave empty to create new VPC
 app_name = "ai-description"
-stage_name = "dev"
+deployment_stage = "dev"
 deployment_name = "your-deployment-name"  # Required
 ```
 

--- a/dev.tfvars
+++ b/dev.tfvars
@@ -6,8 +6,8 @@ vpc_id = ""
 # Application name
 app_name = "ai-description"
 
-# API Gateway stage name
-stage_name = "dev"
+# Deployment stage
+deployment_stage = "dev"
 
 # Deployment name (ENTER HERE OR REQUIRED TO INPUT BEFORE DEPLOYMENT)
 # deployment_name = ""

--- a/projects/infra/modules/api_gateway/main.tf
+++ b/projects/infra/modules/api_gateway/main.tf
@@ -259,7 +259,7 @@ resource "aws_api_gateway_deployment" "api_deployment" {
 resource "aws_api_gateway_stage" "api_stage" {
   deployment_id = aws_api_gateway_deployment.api_deployment.id
   rest_api_id   = aws_api_gateway_rest_api.api.id
-  stage_name    = var.stage_name
+  stage_name    = var.deployment_stage
 }
 
 resource "aws_api_gateway_method_settings" "all" {

--- a/projects/infra/modules/api_gateway/outputs.tf
+++ b/projects/infra/modules/api_gateway/outputs.tf
@@ -5,5 +5,5 @@
 
 output "api_endpoint" {
   description = "The URL of the API Gateway endpoint"
-  value       = "${aws_api_gateway_deployment.api_deployment.invoke_url}${var.stage_name}/"
+  value       = "${aws_api_gateway_deployment.api_deployment.invoke_url}${var.deployment_stage}/"
 }

--- a/projects/infra/modules/api_gateway/variables.tf
+++ b/projects/infra/modules/api_gateway/variables.tf
@@ -8,7 +8,7 @@ variable "lambda" {
   type        = map(string)
 }
 
-variable "stage_name" {
+variable "deployment_stage" {
   description = "Deployment stage name for the environment"
   type        = string
   default     = "dev"

--- a/projects/infra/modules/ecr/main.tf
+++ b/projects/infra/modules/ecr/main.tf
@@ -7,7 +7,7 @@
 resource "aws_ecr_repository" "processor" {
   name                 = "${var.deployment_prefix}-processor-repo"
   image_tag_mutability = "MUTABLE"
-  force_delete         = var.stage_name == "dev"
+  force_delete         = var.deployment_stage == "dev"
 
   image_scanning_configuration {
     scan_on_push = true

--- a/projects/infra/modules/ecr/variables.tf
+++ b/projects/infra/modules/ecr/variables.tf
@@ -8,7 +8,7 @@ variable "deployment_prefix" {
   type        = string
 }
 
-variable "stage_name" {
+variable "deployment_stage" {
   description = "Deployment stage name for the environment"
   type        = string
 }

--- a/projects/infra/modules/ecs/variables.tf
+++ b/projects/infra/modules/ecs/variables.tf
@@ -38,7 +38,7 @@ variable "deployment_prefix_logs" {
   type        = string
 }
 
-variable "stage_name" {
+variable "deployment_stage" {
   description = "Deployment stage name for the environment"
   type        = string
 }

--- a/projects/infra/modules/s3/main.tf
+++ b/projects/infra/modules/s3/main.tf
@@ -4,12 +4,12 @@
 # S3 module
 
 locals {
-  force_destroy = var.stage_name == "dev" ? true : false
+  force_destroy = var.deployment_stage == "dev" ? true : false
 }
 
 # Uploads bucket
 resource "aws_s3_bucket" "uploads" {
-  bucket        = "${var.global_deployment_prefix}-uploads"
+  bucket        = "${var.deployment_prefix_global}-uploads"
   force_destroy = local.force_destroy
 }
 
@@ -33,7 +33,7 @@ resource "aws_s3_bucket_public_access_block" "uploads_public_access_block" {
 
 # Logs bucket
 resource "aws_s3_bucket" "logs" {
-  bucket        = "${var.global_deployment_prefix}-logs"
+  bucket        = "${var.deployment_prefix_global}-logs"
   force_destroy = local.force_destroy
 }
 
@@ -57,6 +57,6 @@ resource "aws_s3_bucket_public_access_block" "logs_public_access_block" {
 
 # Lambda code bucket
 resource "aws_s3_bucket" "lambda_code" {
-  bucket        = "${var.global_deployment_prefix}-lambda-code"
+  bucket        = "${var.deployment_prefix_global}-lambda-code"
   force_destroy = local.force_destroy
 }

--- a/projects/infra/modules/s3/variables.tf
+++ b/projects/infra/modules/s3/variables.tf
@@ -8,12 +8,12 @@ variable "deployment_prefix" {
   type        = string
 }
 
-variable "global_deployment_prefix" {
+variable "deployment_prefix_global" {
   description = "Global unique name of the deployment"
   type        = string
 }
 
-variable "stage_name" {
+variable "deployment_stage" {
   description = "Deployment stage name for the environment"
   type        = string
 }

--- a/projects/infra/variables.tf
+++ b/projects/infra/variables.tf
@@ -28,7 +28,7 @@ variable "deployment_name" {
   }
 }
 
-variable "stage_name" {
+variable "deployment_stage" {
   description = "Deployment stage name for the environment"
   type        = string
   default     = "dev"


### PR DESCRIPTION
This PR includes:
- Small naming refactors for consistency and clarity including:
   - `stage_name` -> `deployment_stage` to better reflect that this variable also goes into the deployment prefix and is not just about the API Gateway stage name
   - `global_deployment_prefix` -> `deployment_prefix_global` to be consistent with the two other variables (`deployment_prefix` and `deployment_prefix_logs`). 
- Doc updates to reflect changes (README.md)