### PR TITLE
Removes s3:HeadObject

### DIFF
--- a/projects/infra/modules/iam/main.tf
+++ b/projects/infra/modules/iam/main.tf
@@ -47,7 +47,6 @@ resource "aws_iam_policy" "create_job_policy" {
         Effect = "Allow"
         Action = [
           "s3:GetObject",
-          "s3:HeadObject",
           "s3:ListBucket",
         ]
         Resource = [
@@ -296,7 +295,6 @@ resource "aws_iam_policy" "get_presigned_url_policy" {
         Effect = "Allow"
         Action = [
           "s3:GetObject",
-          "s3:HeadObject",
           "s3:ListBucket",
         ]
         Resource = [
@@ -439,21 +437,11 @@ resource "aws_iam_policy" "ecs_task_policy" {
         Effect = "Allow"
         Action = [
           "s3:GetObject",
-          "s3:HeadObject",
           "s3:ListBucket",
         ]
         Resource = [
           "${var.uploads_bucket_arn}",
           "${var.uploads_bucket_arn}/*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "s3:ListBucket"
-        ]
-        Resource = [
-          var.uploads_bucket_arn
         ]
       },
       {
@@ -583,7 +571,6 @@ resource "aws_vpc_endpoint_policy" "s3_policy" {
         Action = [
           "s3:GetObject",
           "s3:ListBucket",
-          "s3:HeadObject",
         ]
         Resource = "*"
       }


### PR DESCRIPTION
HeadObject is [an API function](https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html) which relies on the [s3:GetObject permission](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-policy-actions.html#using-with-s3-policy-actions-related-to-objects). s3:HeadObject was granted in places that already also granted s3:GetObject.

The ECS task policy also grants the s3:ListBucket permission twice, so the repeat is removed.